### PR TITLE
optimize key pool initialization

### DIFF
--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -69,7 +69,7 @@ std::shared_ptr<CWallet> GetWallet(const std::string& name);
 std::shared_ptr<CWallet> LoadWallet(interfaces::Chain& chain, const WalletLocation& location, std::string& error, std::string& warning);
 
 //! Default for -keypool
-static const unsigned int DEFAULT_KEYPOOL_SIZE = 1000;
+static const unsigned int DEFAULT_KEYPOOL_SIZE = 100;
 //! -paytxfee default
 constexpr CAmount DEFAULT_PAY_TX_FEE = 0;
 //! -fallbackfee default


### PR DESCRIPTION
when bitcoind started, it costs too much time creating key pool(too much keys, 1000). Here change key number from 1000 to 100.